### PR TITLE
disable languages by default

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -781,7 +781,7 @@ datastore:
 # languages config
 languages:
     # whether to load languages
-    enabled: true
+    enabled: false
 
     # default language to use for new clients
     # 'en' is the default English language in the code


### PR DESCRIPTION
## disable languages by default

- *Description of why you made this PR*

https://github.com/YunoHost-Apps/ergo_ynh/issues/34

```
2026/01/14 09:04:02 Config file did not load successfully: Could not load languages: Cannot find default language [fr-FR]
```

## Solution

Disable languages in Ergo (they are not very useful to most operators).

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
